### PR TITLE
fixes parameter in lognormal-moments.Rd example code

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
 
 build_script:
   - R --version
-  - travis-tool.sh install_github appling/unitted@v0.2.5 USGS-R/smwrData@v1.1.0 USGS-R/smwrBase@v1.1.0 USGS-R/smwrGraphs@v1.1.0 USGS-R/smwrStats@v0.7.2 USGS-R/smwrQW@v0.7.5 USGS-R/rloadest@v0.4.2
+  - travis-tool.sh install_github appling/unitted@v0.2.4 USGS-R/smwrData@v1.1.0 USGS-R/smwrBase@v1.1.0 USGS-R/smwrGraphs@v1.1.0 USGS-R/smwrStats@v0.7.2 USGS-R/smwrQW@v0.7.5 USGS-R/rloadest@v0.4.2
   - travis-tool.sh install_deps
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
 
 build_script:
   - R --version
-  - travis-tool.sh install_github appling/unitted@v0.2.4 USGS-R/smwrData@v1.1.0 USGS-R/smwrBase@v1.1.0 USGS-R/smwrGraphs@v1.1.0 USGS-R/smwrStats@v0.7.2 USGS-R/smwrQW@v0.7.5 USGS-R/rloadest@v0.4.2
+  - travis-tool.sh install_github appling/unitted@v0.2.5 USGS-R/smwrData@v1.1.0 USGS-R/smwrBase@v1.1.0 USGS-R/smwrGraphs@v1.1.0 USGS-R/smwrStats@v0.7.2 USGS-R/smwrQW@v0.7.5 USGS-R/rloadest@v0.4.2
   - travis-tool.sh install_deps
 
 test_script:

--- a/man/lognormal-moments.Rd
+++ b/man/lognormal-moments.Rd
@@ -89,12 +89,12 @@ library(ggplot2)
 logparams <- list(meanlog = 1, sdlog = 0.5)
 loglin_data <- data.frame(rlnorm=rlnorm(1000, meanlog=logparams$meanlog, sdlog=logparams$sdlog))
 ggplot(loglin_data, aes(x=log(rlnorm))) + geom_density() +
-  geom_vline(x=logparams$meanlog, color="red") +
-  geom_vline(x=logparams$meanlog+c(-1,1)*logparams$sdlog, color="blue")
+  geom_vline(xintercept=logparams$meanlog, color="red") +
+  geom_vline(xintercept=logparams$meanlog+c(-1,1)*logparams$sdlog, color="blue")
 linparams <- logToLin(ms=logparams)
 ggplot(loglin_data, aes(x=rlnorm)) + geom_density() +
-  geom_vline(x=linparams$meanlin, color="red") +
-  geom_vline(x=linparams$meanlin+c(-1,1)*linparams$sdlin, color="blue")
+  geom_vline(xintercept=linparams$meanlin, color="red") +
+  geom_vline(xintercept=linparams$meanlin+c(-1,1)*linparams$sdlin, color="blue")
 #
 # logToLin
 logToLin(meanlog=1, sdlog=0.5)


### PR DESCRIPTION
Example code in lognormal-moments.Rd contained an unkown parameter geom_vline needs a parameter named xintercept instead of x. 