### PR TITLE
aggregateSolute preds and custom data.frames

### DIFF
--- a/R/aggregateSolute.R
+++ b/R/aggregateSolute.R
@@ -25,7 +25,7 @@
 #' @importFrom smwrBase waterYear
 #' @importFrom unitted u v get_units
 #' @param preds Either a vector of predicted instantaneous fluxes or 
-#'   concentrations or a data.frame containing the columns "fit", "se.pred", and
+#'   concentrations or a data.frame containing the columns "conc.fit", "se.pred", and
 #'   "date"
 #' @param metadata A metadata object describing the model
 #' @param format character. The desired format of the aggregated values. If 
@@ -128,19 +128,15 @@ aggregateSolute <- function(
   ci.distrib <- match.arg.loadflex(ci.distrib, c("lognormal","normal"))
   if(is.data.frame(preds)) {
     dates <- preds[,eval(metadata@dates)] #this should be metadata@dates
-    if(format=="conc" & "conc.se.pred" %in% colnames(preds)) {#if("d" %in% colnames(dat))
-      se.preds <- preds$conc.se.pred
-    }else if(format=="flux" & "flux.se.pred" %in% colnames(preds)){
-      se.preds <- preds$flux.se.pred
+    if("se.pred" %in% colnames(preds)) {#if("d" %in% colnames(dat))
+      se.preds <- preds$se.pred
     }else{
-      stop("could not find a column named either conc.se.pred or flux.se.pred in the custom preds dataframe.")
+      stop("could not find a column named se.pred in the custom preds dataframe.")
       }
-    if(format=="conc" & "conc.fit" %in% colnames(preds)){ 
-      preds <- preds$conc.fit
-    }else if(format=="flux"& "flux.fit" %in% colnames(preds)){
-      preds <- preds$flux.fit
+    if("fit" %in% colnames(preds)){ 
+      preds <- preds$fit
     }else{
-      stop("could not find a column named either conc.fit or flux.fit in the custom preds dataframe.")
+      stop("could not find a column named fit in the custom preds dataframe.")
     }
   }
   

--- a/R/aggregateSolute.R
+++ b/R/aggregateSolute.R
@@ -25,7 +25,7 @@
 #' @importFrom smwrBase waterYear
 #' @importFrom unitted u v get_units
 #' @param preds Either a vector of predicted instantaneous fluxes or 
-#'   concentrations or a data.frame containing the columns "conc.fit", "se.pred", and
+#'   concentrations or a data.frame containing the columns "fit", "se.pred", and
 #'   "date"
 #' @param metadata A metadata object describing the model
 #' @param format character. The desired format of the aggregated values. If 
@@ -106,7 +106,6 @@ aggregateSolute <- function(
   cormat.function=cormat1DayBand,
   ci.agg=TRUE, level=0.95, deg.free=NA, ci.distrib=c("lognormal","normal"), se.agg=TRUE,
   na.rm=FALSE, attach.units=FALSE) {
-  
   # Validate arguments
   format <- match.arg.loadflex(format, c("conc", "flux rate", "flux total"))
   attach.units <- match.arg.loadflex(attach.units)
@@ -333,11 +332,9 @@ aggregateSolute <- function(
     # Shake off any pre-existing units - e.g., those attached to Duration
     agg_preds <- v(agg_preds)
   }
-  
   # Give the data.frame nice column names
   names(agg_preds)[1] <- .reSpace(.sentenceCase(names(agg_preds)[1]), "_")
   names(agg_preds)[match("Value", names(agg_preds))] <- .reSpace(.sentenceCase(format), "_")
-  
   # Return
   agg_preds
 }

--- a/R/aggregateSolute.R
+++ b/R/aggregateSolute.R
@@ -106,7 +106,7 @@ aggregateSolute <- function(
   cormat.function=cormat1DayBand,
   ci.agg=TRUE, level=0.95, deg.free=NA, ci.distrib=c("lognormal","normal"), se.agg=TRUE,
   na.rm=FALSE, attach.units=FALSE) {
-
+  
   # Validate arguments
   format <- match.arg.loadflex(format, c("conc", "flux rate", "flux total"))
   attach.units <- match.arg.loadflex(attach.units)
@@ -127,9 +127,21 @@ aggregateSolute <- function(
   }
   ci.distrib <- match.arg.loadflex(ci.distrib, c("lognormal","normal"))
   if(is.data.frame(preds)) {
-    dates <- preds$date
-    se.preds <- preds$se.pred
-    preds <- preds$fit
+    dates <- preds[,eval(metadata@dates)] #this should be metadata@dates
+    if(format=="conc" & "conc.se.pred" %in% colnames(preds)) {#if("d" %in% colnames(dat))
+      se.preds <- preds$conc.se.pred
+    }else if(format=="flux" & "flux.se.pred" %in% colnames(preds)){
+      se.preds <- preds$flux.se.pred
+    }else{
+      stop("could not find a column named either conc.se.pred or flux.se.pred in the custom preds dataframe.")
+      }
+    if(format=="conc" & "conc.fit" %in% colnames(preds)){ 
+      preds <- preds$conc.fit
+    }else if(format=="flux"& "flux.fit" %in% colnames(preds)){
+      preds <- preds$flux.fit
+    }else{
+      stop("could not find a column named either conc.fit or flux.fit in the custom preds dataframe.")
+    }
   }
   
   # Check that dates contains actual dates
@@ -325,11 +337,11 @@ aggregateSolute <- function(
     # Shake off any pre-existing units - e.g., those attached to Duration
     agg_preds <- v(agg_preds)
   }
-
+  
   # Give the data.frame nice column names
   names(agg_preds)[1] <- .reSpace(.sentenceCase(names(agg_preds)[1]), "_")
   names(agg_preds)[match("Value", names(agg_preds))] <- .reSpace(.sentenceCase(format), "_")
- 
+  
   # Return
   agg_preds
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,4 @@
-#just trigger travis. Trigger again. 
+#just trigger travis.
 library(testthat)
 library(loadflex)
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,4 @@
-#just trigger travis. 
+#just trigger travis. Trigger again. 
 library(testthat)
 library(loadflex)
 

--- a/tests/testthat/test-33-aggregateSolute.R
+++ b/tests/testthat/test-33-aggregateSolute.R
@@ -86,23 +86,23 @@ test_that("Confidence intervals can be calculated with normal or lognormal assum
                                dates=reg.preds$DATES, agg.by="month", ci.distrib="lognormal")
   normpreds <- aggregateSolute(reg.preds$conc.fit, se.preds=reg.preds$conc.se.pred, format="conc", metadata=getMetadata(reg.model), 
                                dates=reg.preds$DATES, agg.by="month", ci.distrib="normal")
-  #   
-  #   regbox.preds <- data.frame(
-  #     simpledata, FLUX=observeSolute(simpledata, "flux", getMetadata(reg.model)), 
-  #     conc=predictSolute(reg.model, "conc", newdata=simpledata, interval="prediction", se.pred=TRUE),
-  #     flux=predictSolute(reg.model, "flux", newdata=simpledata, interval="prediction", se.pred=TRUE))
-  #   
-  #   regbox2<- boxCox(regbox.preds$conc.fit)
-  #   normpredsbox <- aggregateSolute(regbox2, se.preds=reg.preds$conc.se.pred, format="conc", metadata=getMetadata(reg.model), 
-  #                                dates=reg.preds$DATES, agg.by="month", ci.distrib="normal")
-  #   
+#   
+#   regbox.preds <- data.frame(
+#     simpledata, FLUX=observeSolute(simpledata, "flux", getMetadata(reg.model)), 
+#     conc=predictSolute(reg.model, "conc", newdata=simpledata, interval="prediction", se.pred=TRUE),
+#     flux=predictSolute(reg.model, "flux", newdata=simpledata, interval="prediction", se.pred=TRUE))
+#   
+#   regbox2<- boxCox(regbox.preds$conc.fit)
+#   normpredsbox <- aggregateSolute(regbox2, se.preds=reg.preds$conc.se.pred, format="conc", metadata=getMetadata(reg.model), 
+#                                dates=reg.preds$DATES, agg.by="month", ci.distrib="normal")
+#   
   expect_equal(sum(lognpreds$Conc), sum(normpreds$Conc))
   
-  #   print(ggplot(lognpreds, aes(x=as.Date(paste0(Month,"-15")), y=Conc)) + theme_bw() + 
-  #           geom_point(color="blue", shape=4, size=3) + geom_ribbon(aes(ymin=CI_lower, ymax=CI_upper), color="blue", fill="blue", alpha=0.2) +
-  #           geom_point(data=normpreds, color="red", shape=3, size=3) + geom_ribbon(data=normpreds, aes(ymin=CI_lower, ymax=CI_upper), color="red", fill="red", alpha=0.2))
-  #   expect_manual_OK("Normal (red) and lognormal (blue) CIs make sense for monthly fluxes")
-  #   
+#   print(ggplot(lognpreds, aes(x=as.Date(paste0(Month,"-15")), y=Conc)) + theme_bw() + 
+#           geom_point(color="blue", shape=4, size=3) + geom_ribbon(aes(ymin=CI_lower, ymax=CI_upper), color="blue", fill="blue", alpha=0.2) +
+#           geom_point(data=normpreds, color="red", shape=3, size=3) + geom_ribbon(data=normpreds, aes(ymin=CI_lower, ymax=CI_upper), color="red", fill="red", alpha=0.2))
+#   expect_manual_OK("Normal (red) and lognormal (blue) CIs make sense for monthly fluxes")
+#   
 })
 
 

--- a/tests/testthat/test-33-aggregateSolute.R
+++ b/tests/testthat/test-33-aggregateSolute.R
@@ -249,9 +249,9 @@ test_that("Aggregations by day (6 per day) pretty much line up with rloadest cou
   
 })
 
-test_that("Test custom An optional data.frame of one or more columns each containing factors or other labels on which to aggregate. Test se.preds as a dataframe.", {
+test_that("Test custom, An optional data.frame of one or more columns each containing factors or other labels on which to aggregate. Test se.preds as a dataframe.", {
   # Define & munge dataset
-  #library(rloadest)
+  library(rloadest)
   simpledata <- transform(app2.calib[-which(diff(app2.calib$DATES) < 7),], 
                           Period=seasons(DATES,breaks=c("Apr", "Jul")))
   simpledata_est <- transform(app2.est, Period=seasons(DATES,breaks=c("Apr", "Jul")))

--- a/tests/testthat/test-33-aggregateSolute.R
+++ b/tests/testthat/test-33-aggregateSolute.R
@@ -278,15 +278,18 @@ test_that("Test custom An optional data.frame of one or more columns each contai
   expect_error(aggregateSolute(agg.by="unit", custom=reg.preds[1:10,], preds=reg.preds$flux.fit, se.preds=reg.preds$flux.se.pred, format="flux total", metadata=getMetadata(reg.model), dates=reg.preds$DATES, na.rm=TRUE),"When custom is a data.frame, it must have as many rows as there are values in preds, se.preds")
   #pass preds as a data.frame
   st <- list()
-  st[["cdf"]][["tot" ]]<- system.time({agg_conc__tot_preds_as_dataframe<- aggregateSolute(agg.by="total", preds=reg.preds, se.preds=reg.preds$conc.se.pred, format="conc", metadata=getMetadata(reg.model), dates=reg.preds$DATES, na.rm=TRUE)})
-  st[["c"]][["tot" ]] <- system.time({agg_conc_tot  <- aggregateSolute(agg.by="total", preds=reg.preds$conc.fit, se.preds=reg.preds$conc.se.pred, format="conc", metadata=getMetadata(reg.model), dates=reg.preds$DATES, na.rm=TRUE)})
+  reg.preds$fit <- reg.preds$flux.fit
+  reg.preds$se.pred <- reg.preds$flux.se.pred
+  drops <- c("flux.se.pred","flux.fit")
+  st[["cdf"]][["tot" ]]<- system.time({agg_flux__tot_preds_as_dataframe<- aggregateSolute(agg.by="total", preds=reg.preds, se.preds=reg.preds$conc.se.pred, format="flux total", metadata=getMetadata(reg.model), dates=reg.preds$DATES, na.rm=TRUE)})
+  st[["c"]][["tot" ]] <- system.time({agg_flux_tot  <- aggregateSolute(agg.by="total", preds=reg.preds$conc.fit, se.preds=reg.preds$conc.se.pred, format="flux total", metadata=getMetadata(reg.model), dates=reg.preds$DATES, na.rm=TRUE)})
   expect_equal(agg_conc__tot_preds_as_dataframe,agg_conc_tot)
-  drops <- c("conc.se.pred","flux.se.pred")
+  drops <- c("se.pred")
   bad.reg.preds <- reg.preds[,!(names(reg.preds) %in% drops)]
-  expect_error(aggregateSolute(agg.by="total", preds=bad.reg.preds, se.preds=reg.preds$conc.se.pred, format="conc", metadata=getMetadata(reg.model), dates=reg.preds$DATES, na.rm=TRUE),"could not find a column named either conc.se.pred or flux.se.pred in the custom preds dataframe.")
-  drops <- c("conc.fit","flux.fit")
+  expect_error(aggregateSolute(agg.by="total", preds=bad.reg.preds, se.preds=reg.preds$conc.se.pred, format="conc", metadata=getMetadata(reg.model), dates=reg.preds$DATES, na.rm=TRUE),"could not find a column named se.pred in the custom preds dataframe.")
+  drops <- c("fit")
   bad.reg.preds <- reg.preds[,!(names(reg.preds) %in% drops)]
-  expect_error(aggregateSolute(agg.by="total", preds=bad.reg.preds, se.preds=reg.preds$conc.se.pred, format="conc", metadata=getMetadata(reg.model), dates=reg.preds$DATES, na.rm=TRUE),"could not find a column named either conc.fit or flux.fit in the custom preds dataframe.")
+  expect_error(aggregateSolute(agg.by="total", preds=bad.reg.preds, se.preds=reg.preds$conc.se.pred, format="conc", metadata=getMetadata(reg.model), dates=reg.preds$DATES, na.rm=TRUE),"could not find a column named fit in the custom preds dataframe.")
   
 })
 

--- a/vignettes/intro_to_loadflex.Rmd
+++ b/vignettes/intro_to_loadflex.Rmd
@@ -105,6 +105,7 @@ getCorrectionFraction(no3_lc, "flux", newdat=intdat)
 Aggregate from point predictions to monthly predictions from each model. You can also do this for mean concentration or total flux for the month, or for years or other time intervals.
 
 ```{r, fig_1E}
+meta@dates <- "date"
 aggs_li <- aggregateSolute(preds_li, meta, "flux rate", "month")
 aggs_lm <- aggregateSolute(preds_lm, meta, "flux rate", "month")
 aggs_lr <- aggregateSolute(preds_lr, meta, "flux rate", "month")


### PR DESCRIPTION
There is an option in aggregateSolute to pass predictions to aggregate as a data.frame, this did not include any checks to make sure that the required column names existed. This adds checks for column names and a test for those in test 33. This also tests some checks on the custom data.frame which had not been reached in previous testing.